### PR TITLE
SMM-0000: Bump app version to 25.9.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "25.9"
+        versionName "25.9.0"
     }
     signingConfigs {
         debug {

--- a/ios/DemoApp.xcodeproj/project.pbxproj
+++ b/ios/DemoApp.xcodeproj/project.pbxproj
@@ -265,7 +265,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 25.9;
+				MARKETING_VERSION = 25.9.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -292,7 +292,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 25.9;
+				MARKETING_VERSION = 25.9.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DemoApp",
-  "version": "25.9",
+  "version": "25.9.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## Summary

This PR was auto generated by running the following script locally:
```bash
./manage-release-branches.sh bump --patch-for-regressions
```

### Release Branch Policy

This PR updates the version number to 25.9.0 in all the necessary places:
- Android (`build.gradle`)
- iOS (`MARKETING_VERSION`)
- JavaScript bundle (`package.json`)

### Overview
Updated the following to 25.9.0:
- `versionName` in `android/app/build.gradle`
- `MARKETING_VERSION` in `ios/DemoApp.xcodeproj/project.pbxproj` 
- `version` in `package.json`

### Context
- Ticket: No ticket—automated version update
- Operation: patch-for-regressions version bump