### PR TITLE
SMM-0000: Bump app version to 25.11

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "25.10"
+        versionName "25.11"
     }
     signingConfigs {
         debug {

--- a/ios/DemoApp.xcodeproj/project.pbxproj
+++ b/ios/DemoApp.xcodeproj/project.pbxproj
@@ -265,7 +265,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 25.10;
+				MARKETING_VERSION = 25.11;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -292,7 +292,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 25.10;
+				MARKETING_VERSION = 25.11;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "DemoApp",
-  "version": "25.10",
+  "version": "25.11",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
## Summary

This PR was auto generated by running the following script locally:
```bash
./manage-release-branches.sh next-release
```

This PR updates the version number to 25.11 in all the necessary places:
- Android (`build.gradle`)
- iOS (`MARKETING_VERSION`)
- JavaScript bundle (`package.json`)

### Release Branch Policy

We can't make these changes when creating the `release/25.11` branch because of the repository's push policy. Specifically, we're not allowed to:
1. Create the release branch locally
2. Make version changes
3. Push it to the remote

Instead, we must:
1. Create the release branch directly from the default branch via the GitHub UI
2. Then open this PR immediately to apply the version updates

### Overview
Updated the following to `25.11`:
- `versionName` in `android/app/build.gradle`
- `MARKETING_VERSION` in `ios/DemoApp.xcodeproj/project.pbxproj`
- `version` in `package.json`

### Context
- Ticket: No ticket—automated version update
- Operation: minor version bump